### PR TITLE
Binomial estimation/testing: remove sequential output on data change

### DIFF
--- a/R/LScommon.R
+++ b/R/LScommon.R
@@ -1392,7 +1392,7 @@ hdi.density    <- function(object, credMass=0.95, allowSplit=FALSE, ...) {
 .containerSequentialStackedLS  <- function(jaspResults, options, analysis) {
 
   if (is.null(jaspResults[["containerIterativeStacked"]])) {
-    containerIterativeStacked <- createJaspContainer(title = gettext("Sequential Analysis: Staked"))
+    containerIterativeStacked <- createJaspContainer(title = gettext("Sequential Analysis: Stacked"))
     containerIterativeStacked$position <- 7.5
     containerIterativeStacked$dependOn("plotsIterativeStacked")
 

--- a/inst/qml/LSbinomialestimation.qml
+++ b/inst/qml/LSbinomialestimation.qml
@@ -154,7 +154,16 @@ Form {
 	LS.LSestimationsequential
 	{
 		enabled: binomialDataInput.dataType.value !== "dataCounts"
-		onEnabledChanged: if(!enabled) expanded = false
+		onEnabledChanged: 
+		{
+			if (!enabled) {
+				expanded = false
+				plotsIterativeOverlying.checked = false
+				plotsIterativeInterval.checked = false
+				plotsIterativeStacked.checked = false
+				doIterative.checked = false
+			}
+		}
 	}
 
 	LS.LSestimationpredictions{}

--- a/inst/qml/LSbinomialtesting.qml
+++ b/inst/qml/LSbinomialtesting.qml
@@ -171,7 +171,8 @@ Form {
 
 	LS.LStestingpriorandposterior{}
 
-	LS.LStestingpredictiveperformance{
+	LS.LStestingpredictiveperformance
+	{
 		bfTypevsName:				"priors.name"
 	}
 
@@ -179,6 +180,13 @@ Form {
 	{
 		enabled:					binomialDataInput.dataType.value !== "dataCounts"
 		bfTypevsNameSequential:		"priors.name"
+		onEnabledChanged: 
+		{
+			if (!enabled) {
+				expanded = false
+				plotsIterative.checked = false
+			}
+		}
 	}
 
 	LS.LStestingpredictions{}

--- a/inst/qml/qml_components/LSestimationsequential.qml
+++ b/inst/qml/qml_components/LSestimationsequential.qml
@@ -27,12 +27,16 @@ Section
 	title:		qsTr("Sequential Analysis")
 
 	property string analysisType:	"binomial"
+	property alias plotsIterativeOverlying:		plotsIterativeOverlying
+	property alias plotsIterativeInterval:		plotsIterativeInterval
+	property alias plotsIterativeStacked:		plotsIterativeStacked
+	property alias doIterative:					doIterative
 
 	CheckBox
 	{
 		name:		"plotsIterativeOverlying"
+		id:			plotsIterativeOverlying
 		label:		qsTr("Point estimate")
-		checked:	false
 
 		DropDown
 		{
@@ -154,6 +158,7 @@ Section
 	CheckBox
 	{
 		name:	"plotsIterativeStacked"
+		id:		plotsIterativeStacked
 		label:	qsTr("Stacked distributions")
 	}
 	
@@ -161,6 +166,7 @@ Section
 	{
 		Layout.columnSpan: 2
 		name:		"doIterative"
+		id:			doIterative
 		label:		qsTr("Posterior updating table")
 		checked:	false
 	}

--- a/inst/qml/qml_components/LStestingsequential.qml
+++ b/inst/qml/qml_components/LStestingsequential.qml
@@ -25,13 +25,14 @@ Section
 {
 	expanded:	false
 	title:		qsTr("Sequential Analysis")
-	enabled:	dataTypeB.checked || dataTypeC.checked
 
 	property alias bfTypevsNameSequential: 	bfTypevsNameSequential.source
+	property alias plotsIterative: 			plotsIterative
 
 	CheckBox
 	{
 		name:		"plotsIterative"
+		id:			plotsIterative
 		label:		qsTr("Test results")
 		checked:	false
 


### PR DESCRIPTION
fixes: https://github.com/jasp-stats/jasp-issues/issues/1423

- now properly removes output from the sequential analysis if the data input is switched to ``Specify counts``