### PR TITLE
The lower and upper fields of the plot prediction type in Predictive Performance should be double instead of integer

### DIFF
--- a/inst/qml/qml_components/LStestingpredictiveperformance.qml
+++ b/inst/qml/qml_components/LStestingpredictiveperformance.qml
@@ -95,7 +95,7 @@ Section
 						inclusive:		JASP.MaxOnly
 					}
 
-					IntegerField
+					DoubleField
 					{
 						visible:		plotsPredictionTypeCI.currentText == "custom"
 						enabled:		plotsPredictionCI.checked
@@ -108,7 +108,7 @@ Section
 						max:			plotsPredictionUpper.value; inclusive: JASP.MinMax
 					}
 
-					IntegerField
+					DoubleField
 					{
 						visible:		plotsPredictionTypeCI.currentText == "custom"
 						enabled:		plotsPredictionCI.checked


### PR DESCRIPTION

The default values of plotsPredictionLower and plotsPredictionUpper can be double if the analysis type is binomial, so their type should be DoubleField instead of IntegerField Fixes https://github.com/jasp-stats/jasp-test-release/issues/1963