### PR TITLE
fix bracket at logBF10 label

### DIFF
--- a/R/LSbinomialtesting.R
+++ b/R/LSbinomialtesting.R
@@ -1081,7 +1081,7 @@ LSbinomialtesting   <- function(jaspResults, dataset, options, state = NULL) {
           options[["sequentialAnalysisPredictivePerformancePlotBfType"]],
           "BF10"    = bquote("BF"["10"]),
           "BF01"    = bquote("BF"["01"]),
-          "LogBF10" = bquote(italic("log")*"(BF)"["10"])
+          "LogBF10" = bquote(italic("log")*"(BF"["10"]*")")
         )
       }
 


### PR DESCRIPTION
now looks as it supposed to (the 10 was outside of the bracket before)

![image](https://github.com/jasp-stats/jaspLearnBayes/assets/38475991/092d2a80-c9d5-4d71-8a3f-88996daf1bbe)
