### PR TITLE
Replace mainWindow by dataSetInfo

### DIFF
--- a/inst/qml/qml_components/LSbinomialdatainput.qml
+++ b/inst/qml/qml_components/LSbinomialdatainput.qml
@@ -42,8 +42,8 @@ Section
 			value:		"variable"
 			label:		qsTr("Select variable")
 			id:			dataInputTypeC
-			checked: 	mainWindow.dataAvailable
-			enabled:	mainWindow.dataAvailable
+			checked: 	dataSetInfo.dataAvailable
+			enabled:	dataSetInfo.dataAvailable
 		}
 
 		RadioButton
@@ -51,7 +51,7 @@ Section
 			value:		"counts"
 			label:		qsTr("Specify counts")
 			id:			dataInputTypeA
-			checked:	!mainWindow.dataAvailable
+			checked:	!dataSetInfo.dataAvailable
 		}
 
 		RadioButton

--- a/inst/qml/qml_components/LSgaussiandatainput.qml
+++ b/inst/qml/qml_components/LSgaussiandatainput.qml
@@ -42,8 +42,8 @@ Section
 			value:		"variable"
 			label:		qsTr("Select variable")
 			id:			dataInputTypeC
-			checked: 	mainWindow.dataAvailable
-			enabled:	mainWindow.dataAvailable
+			checked: 	dataSetInfo.dataAvailable
+			enabled:	dataSetInfo.dataAvailable
 		}
 
 		RadioButton
@@ -51,7 +51,7 @@ Section
 			value:		"counts"
 			label:		qsTr("Specify data summary")
 			id:			dataInputTypeA
-			checked:	!mainWindow.dataAvailable
+			checked:	!dataSetInfo.dataAvailable
 		}
 
 		RadioButton


### PR DESCRIPTION
QML analysis files should not use objects that are not defined outside the QMLComponents library.

Cf jasp-stats/jasp-desktop#5281