### PR TITLE
Make strings translatable

### DIFF
--- a/R/LSbinomialtesting.R
+++ b/R/LSbinomialtesting.R
@@ -195,12 +195,7 @@ LSbinomialtesting   <- function(jaspResults, dataset, options, state = NULL) {
       }
 
       # add footnote clarifying what dataset was used
-      testsTable$addFootnote(gettextf(
-        "These results are based on %1$i %2$s and %3$i %4$s.",
-        data[["nSuccesses"]], ifelse (data[["nSuccesses"]] == 1, gettext("success"), gettext("successes")),
-        data[["nFailures"]],  ifelse (data[["nFailures"]]  == 1, gettext("failure"), gettext("failures"))
-      ))
-
+      testsTable$addFootnote(gettextf("These results are based on %1$i success(es) and %2$i failure(s)", data[["nSuccesses"]], data[["nFailures"]]))
     }
 
   }
@@ -1462,13 +1457,10 @@ LSbinomialtesting   <- function(jaspResults, dataset, options, state = NULL) {
       ))
 
       # add footnote clarifying what dataset was used
-      predictionsTable$addFootnote(gettextf(
-        "The prediction for %1$s %2$s is based on %3$s %4$s and %5$s %6$s.",
-        options[["posteriorPredictionNumberOfFutureTrials"]], ifelse (options[["posteriorPredictionNumberOfFutureTrials"]] == 1, gettext("observation"), gettext("observations")),
-        data[["nSuccesses"]], ifelse (data[["nSuccesses"]] == 1, gettext("success"), gettext("successes")),
-        data[["nFailures"]], ifelse (data[["nFailures"]] == 1, gettext("failure"), gettext("failures"))
-      ))
-
+      predictionsTable$addFootnote(gettextf("The prediction for %1$i observation(s) is based on %2$i success(es) and $3$i failure(s)",
+                                    options[["posteriorPredictionNumberOfFutureTrials"]],
+                                    data[["nSuccesses"]],
+                                    data[["nFailures"]]))
     }
   }
 

--- a/R/LSbinomialtesting.R
+++ b/R/LSbinomialtesting.R
@@ -1457,7 +1457,7 @@ LSbinomialtesting   <- function(jaspResults, dataset, options, state = NULL) {
       ))
 
       # add footnote clarifying what dataset was used
-      predictionsTable$addFootnote(gettextf("The prediction for %1$i observation(s) is based on %2$i success(es) and $3$i failure(s)",
+      predictionsTable$addFootnote(gettextf("The prediction for %1$i observation(s) is based on %2$i success(es) and %3$i failure(s)",
                                     options[["posteriorPredictionNumberOfFutureTrials"]],
                                     data[["nSuccesses"]],
                                     data[["nFailures"]]))

--- a/R/LScommon.R
+++ b/R/LScommon.R
@@ -1512,9 +1512,9 @@ hdi.density    <- function(object, credMass=0.95, allowSplit=FALSE, ...) {
     translatedType <- switch(type, "Prior" = gettext("Prior"), "Posterior" = gettext("Posterior"), type)
     containerPlots <- createJaspContainer(title = switch(
                          options[[ifelse (type == "Prior", "priorDistributionPlotType", "posteriorDistributionPlotType")]],
-                         "conditional" = gettext("Conditional %s Plots", type),
-                         "joint"       = gettext("Joint %s Plots", type),
-                         "marginal"    = gettext("Marginal %s Plots", type)))
+                         "conditional" = gettextf("Conditional %s Plots", type),
+                         "joint"       = gettextf("Joint %s Plots", type),
+                         "marginal"    = gettextf("Marginal %s Plots", type)))
     containerPlots$dependOn(c(
       ifelse (type == "Prior", "priorDistributionPlot", "posteriorDistributionPlot"),
       ifelse (type == "Prior", "priorDistributionPlotType", "posteriorDistributionPlotType")

--- a/R/LScommon.R
+++ b/R/LScommon.R
@@ -1509,15 +1509,12 @@ hdi.density    <- function(object, credMass=0.95, allowSplit=FALSE, ...) {
 .containerPlots2LS             <- function(jaspResults, options, analysis, type) {
 
   if (is.null(jaspResults[[paste0("containerPlots", type)]])) {
-    containerPlots <- createJaspContainer(title = gettextf(
-      "%1$s %2$s Plots",
-      switch(
-        options[[ifelse (type == "Prior", "priorDistributionPlotType", "posteriorDistributionPlotType")]],
-        "conditional" = gettext("Conditional"),
-        "joint"       = gettext("Joint"),
-        "marginal"    = gettext("Marginal")
-      ),
-      type))
+    translatedType <- switch(type, "Prior" = gettext("Prior"), "Posterior" = gettext("Posterior"), type)
+    containerPlots <- createJaspContainer(title = switch(
+                         options[[ifelse (type == "Prior", "priorDistributionPlotType", "posteriorDistributionPlotType")]],
+                         "conditional" = gettext("Conditional %s Plots", type),
+                         "joint"       = gettext("Joint %s Plots", type),
+                         "marginal"    = gettext("Marginal %s Plots", type)))
     containerPlots$dependOn(c(
       ifelse (type == "Prior", "priorDistributionPlot", "posteriorDistributionPlot"),
       ifelse (type == "Prior", "priorDistributionPlotType", "posteriorDistributionPlotType")


### PR DESCRIPTION
gettext inside gettext does not work: gettextf("Conditional %s Plots", ifelse(type == "Prior", gettext("Prior"), gettext("Posterior")))

Fixes https://github.com/jasp-stats/jasp-issues/issues/1150

Documentation https://github.com/jasp-stats/jasp-desktop/blob/development/Docs/development/translate.md has been updated.