### PR TITLE
Fix binary classification JAGS issues.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,7 @@ Imports:
   scales,
   ggalluvial,
   ragg,
+  rjags,
   runjags,
   ggdist,
   grid,

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,12 @@
+.onLoad <- function(libname, pkgname) {
+
+  if (jaspBase:::getOS() == "osx" &&
+      isTRUE(try(jaspBase::jaspResultsCalledFromJasp()))
+  ) {
+
+    jagsHome <- Sys.getenv("JAGS_HOME")
+    options(jags.moddir = file.path(jagsHome, "modules-4"))
+    runjags::runjags.options(jagspath = jagsHome)
+
+  }
+}


### PR DESCRIPTION
Small fix for such an issues ;)

Makes sure rjags is present so it is used to find jags.
This is the default for runjags if rjags is present.

Tested on windows 11 and macOS arm64 latest (no jags installed)

https://static.jasp-stats.org/Nightlies/
latest fixlearnBayes nightlies can be used to test if you want to.

Fixes: https://github.com/jasp-stats/jasp-issues/issues/2531
Fixes: https://github.com/jasp-stats/jasp-issues/issues/2537