### PR TITLE
Initiating enter sequence as 0 success 0 failures for prior prediction table

### DIFF
--- a/R/LSbinomialcommon.R
+++ b/R/LSbinomialcommon.R
@@ -18,12 +18,7 @@
 # data load and summary
 .readyBinomialLS       <- function(options) {
   # are data ready
-  if (options[["dataInputType"]] == "counts")
-    readyData <- TRUE
-  else if (options[["dataInputType"]] == "sequence")
-    readyData <- length(options[["dataSequenceSuccesses"]]) > 0 || length(options[["dataSequenceFailures"]]) > 0
-  else if (options[["dataInputType"]] == "variable")
-    readyData <- length(options[["dataVariableSuccesses"]]) > 0 || length(options[["dataVariableFailures"]]) > 0
+  readyData <- length(options[["dataInputType"]]) > 0
 
   # are priors ready
   readyPriors <- length(options[["models"]]) > 0

--- a/R/LSbinomialestimation.R
+++ b/R/LSbinomialestimation.R
@@ -559,7 +559,7 @@ LSbinomialestimation   <- function(jaspResults, dataset, options, state = NULL) 
                               "colorPalette"))
     containerIterative[["plotsIterative"]] <- plotsIterative
 
-    if (!all(ready))
+    if (!all(ready) || sum(data$nSuccesses, data$nFailures) == 0)
       return()
 
     plotDataLines <- list()
@@ -728,7 +728,7 @@ LSbinomialestimation   <- function(jaspResults, dataset, options, state = NULL) 
       plotsIterative[[""]] <- createJaspPlot(title = "", width = 530, height = 400, aspectRatio = 0.7)
       return()
 
-    } else if (!ready["data"] && ready["models"]) {
+    } else if ((!ready["data"] && ready["models"]) || sum(data$nSuccesses, data$nFailures) == 0) {
 
       for (i in 1:length(options[["models"]])) {
         plotsIterative[[options[["models"]][[i]]$name]] <- createJaspPlot(title = options[["models"]][[i]]$name,
@@ -819,7 +819,7 @@ LSbinomialestimation   <- function(jaspResults, dataset, options, state = NULL) 
                                       "sequentialAnalysisIntervalEstimatePlotLower", "sequentialAnalysisIntervalEstimatePlotUpper", "colorPalette"))
     containerIterativeInterval[["sequentialAnalysisIntervalEstimatePlot"]] <- plotsIterativeInterval
 
-    if (!all(ready))
+    if (!all(ready) || sum(data$nSuccesses, data$nFailures) == 0)
       return()
 
 
@@ -892,7 +892,7 @@ LSbinomialestimation   <- function(jaspResults, dataset, options, state = NULL) 
       plotsIterativeInterval[[""]] <- createJaspPlot(title = "", width = 530, height = 400, aspectRatio = 0.7)
       return()
 
-    } else if (!ready["data"] && ready["models"]) {
+    } else if ((!ready["data"] && ready["models"]) || sum(data$nSuccesses, data$nFailures) == 0) {
 
       for (i in 1:length(options[["models"]])) {
         plotsIterativeInterval[[options[["models"]][[i]]$name]] <- createJaspPlot(title = options[["models"]][[i]]$name,

--- a/R/LSbinomialestimation.R
+++ b/R/LSbinomialestimation.R
@@ -128,17 +128,14 @@ LSbinomialestimation   <- function(jaspResults, dataset, options, state = NULL) 
 
     estimatesContainer[["estimatesTable"]] <- estimatesTable
 
+    if ((options[["dataInputType"]] == "variable" && options[["dataVariableSelected"]] != "" && sum(data$nSuccesses, data$nFailures) == 0) ||
+        (options[["dataInputType"]] == "sequence" && options[["dataSequenceSequenceOfObservations"]] != "" && sum(data$nSuccesses, data$nFailures) == 0))
+      estimatesTable$addFootnote(gettext("Please specify successes and failures."))
+
     if (ready["data"] && !ready["models"])
       return()
-    else if (!ready["data"]) {
 
-      if ((options[["dataInputType"]] == "variable" && options[["dataVariableSelected"]]  != "") ||
-          (options[["dataInputType"]] == "sequence" && options[["dataSequenceSequenceOfObservations"]] != ""))
-        estimatesTable$addFootnote(gettext("Please specify successes and failures."))
-
-      return()
-
-    } else if (ready["models"]) {
+    else if (ready["models"]) {
 
       # add rows for each hypothesis
       for (i in 1:length(options[["models"]])) {
@@ -210,7 +207,7 @@ LSbinomialestimation   <- function(jaspResults, dataset, options, state = NULL) 
     }
 
 
-    if (!all(ready))
+    if (!all(ready) || (ready["models"] && sum(data$nSuccesses, data$nFailures) == 0))
       return()
     else {
       # add models to the first row
@@ -1019,7 +1016,7 @@ LSbinomialestimation   <- function(jaspResults, dataset, options, state = NULL) 
       }
     }
 
-    if (!all(ready))
+    if (!all(ready) || (ready["models"] && sum(data$nSuccesses, data$nFailures) == 0))
       return()
 
     iterSeq <- 0:length(data[["y"]])
@@ -1097,7 +1094,7 @@ LSbinomialestimation   <- function(jaspResults, dataset, options, state = NULL) 
       }
     }
 
-    if (!all(ready))
+    if (!all(ready) || (ready["models"] && sum(data$nSuccesses, data$nFailures) == 0))
       return()
 
     iterSeq <- 0:length(data[["y"]])
@@ -1150,17 +1147,14 @@ LSbinomialestimation   <- function(jaspResults, dataset, options, state = NULL) 
 
     containerPredictions[["predictionsTable"]] <- predictionsTable
 
+    if ((options[["dataInputType"]] == "variable" && options[["dataVariableSelected"]] != "" && sum(data$nSuccesses, data$nFailures) == 0) ||
+        (options[["dataInputType"]] == "sequence" && options[["dataSequenceSequenceOfObservations"]] != "" && sum(data$nSuccesses, data$nFailures) == 0))
+      predictionsTable$addFootnote(gettext("Please specify successes and failures."))
+
     if (ready["data"] && !ready["models"])
       return()
-    else if (!ready["data"]) {
 
-      if ((options[["dataInputType"]] == "variable" && options[["dataVariableSelected"]] != "") ||
-          (options[["dataInputType"]] == "sequence" && options[["dataSequenceSequenceOfObservations"]]    != ""))
-        predictionsTable$addFootnote(gettext("Please specify successes and failures."))
-
-      return()
-
-    } else {
+    else {
 
       # add rows for each hypothesis
       for (i in 1:length(options[["models"]])) {
@@ -1413,6 +1407,9 @@ LSbinomialestimation   <- function(jaspResults, dataset, options, state = NULL) 
       tablePredictions$addColumns(0:options[["posteriorPredictionNumberOfFutureTrials"]])
     }
 
+    if ((options[["dataInputType"]] == "variable" && options[["dataVariableSelected"]] != "" && sum(data$nSuccesses, data$nFailures) == 0) ||
+        (options[["dataInputType"]] == "sequence" && options[["dataSequenceSequenceOfObservations"]] != "" && sum(data$nSuccesses, data$nFailures) == 0))
+      tablePredictions$addFootnote(gettext("Please specify successes and failures."))
 
     if (ready["models"]) {
       for (i in seq_along(options[["models"]])) {
@@ -1420,16 +1417,6 @@ LSbinomialestimation   <- function(jaspResults, dataset, options, state = NULL) 
       }
     } else
       return()
-
-
-    if (!ready["data"]) {
-
-      if ((options[["dataInputType"]] == "variable" && options[["dataVariableSelected"]]     != "") ||
-          (options[["dataInputType"]] == "sequence" && options[["dataSequenceSequenceOfObservations"]]    != ""))
-        tablePredictions$addFootnote(gettext("Please specify successes and failures."))
-
-      return()
-    }
 
 
     tempPred    <- NULL

--- a/R/LSbinomialtesting.R
+++ b/R/LSbinomialtesting.R
@@ -151,16 +151,14 @@ LSbinomialtesting   <- function(jaspResults, dataset, options, state = NULL) {
 
     testsContainer[["testsTable"]] <- testsTable
 
+    if ((options[["dataInputType"]] == "variable" && options[["dataVariableSelected"]] != "" && sum(data$nSuccesses, data$nFailures) == 0) ||
+        (options[["dataInputType"]] == "sequence" && options[["dataSequenceSequenceOfObservations"]] != "" && sum(data$nSuccesses, data$nFailures) == 0))
+      testsTable$addFootnote(gettext("Please specify successes and failures."))
+
     if (ready["data"] && !ready["models"])
       return()
-    else if (!ready["data"]) {
 
-      if ((options[["dataInputType"]] == "variable" && options[["dataVariableSelected"]]  != "") ||
-          (options[["dataInputType"]] == "sequence" && options[["dataSequenceSequenceOfObservations"]] != ""))
-        testsTable$addFootnote(gettext("Please specify successes and failures."))
-
-      return()
-    } else if (ready["models"]) {
+    else if (ready["models"]) {
 
       tempResults  <- .testBinomialLS(data, options[["models"]])
       marglikIssue <- FALSE
@@ -943,6 +941,13 @@ LSbinomialtesting   <- function(jaspResults, dataset, options, state = NULL) {
     }
 
 
+    if (type != "Prior") {
+
+      if ((options[["dataInputType"]] == "variable" && options[["dataVariableSelected"]] != "" && sum(data$nSuccesses, data$nFailures) == 0) ||
+          (options[["dataInputType"]] == "sequence" && options[["dataSequenceSequenceOfObservations"]] != "" && sum(data$nSuccesses, data$nFailures) == 0))
+        tablePredictions$addFootnote(gettext("Please specify successes and failures."))
+    }
+
     if (ready["models"]) {
       if (options[[ifelse (type == "Prior", "priorPredictivePerformanceDistributionPlotType", "posteriorPredictionDistributionPlotType")]] %in% c("joint", "conditional")) {
         for (i in seq_along(options[["models"]])) {
@@ -950,18 +955,10 @@ LSbinomialtesting   <- function(jaspResults, dataset, options, state = NULL) {
         }
       } else if (options[[ifelse (type == "Prior", "priorPredictivePerformanceDistributionPlotType", "posteriorPredictionDistributionPlotType")]] == "marginal")
         tablePredictions$addColumnInfo(name = "marginal", title = gettextf("P(Successes)"), type = "number")
-    } else
-      return()
-
-
-    if (!ready["data"] && type != "Prior") {
-
-      if ((options[["dataInputType"]] == "variable" && options[["dataVariableSelected"]] != "") ||
-          (options[["dataInputType"]] == "sequence" && options[["dataSequenceSequenceOfObservations"]]    != ""))
-        tablePredictions$addFootnote(gettext("Please specify successes and failures."))
-
-      return()
     }
+
+    if (!ready["models"] || (ready["models"] && sum(data$nSuccesses, data$nFailures) == 0))
+      return()
 
 
     tempResults <- .testBinomialLS(tempData, options[["models"]])
@@ -1195,7 +1192,7 @@ LSbinomialtesting   <- function(jaspResults, dataset, options, state = NULL) {
     }
 
 
-    if (!all(ready))
+    if (!all(ready) || (ready["models"] && sum(data$nSuccesses, data$nFailures) == 0))
       return()
 
     if (options[["sequentialAnalysisPredictivePerformancePlotType"]] == "BF") {
@@ -1475,17 +1472,14 @@ LSbinomialtesting   <- function(jaspResults, dataset, options, state = NULL) {
 
     containerPredictions[["predictionsTable"]] <- predictionsTable
 
+    if ((options[["dataInputType"]] == "variable" && options[["dataVariableSelected"]] != "" && sum(data$nSuccesses, data$nFailures) == 0) ||
+        (options[["dataInputType"]] == "sequence" && options[["dataSequenceSequenceOfObservations"]] != "" && sum(data$nSuccesses, data$nFailures) == 0))
+      predictionsTable$addFootnote(gettext("Please specify successes and failures."))
+
     if (ready["data"] && !ready["models"])
       return()
-    else if (!ready["data"]) {
 
-      if ((options[["dataInputType"]] == "variable" && options[["dataVariableSelected"]] != "") ||
-          (options[["dataInputType"]] == "sequence" && options[["dataSequenceSequenceOfObservations"]]    != ""))
-        predictionsTable$addFootnote(gettext("Please specify successes and failures."))
-
-      return()
-
-    } else {
+    else {
 
       tempTests <- .testBinomialLS(data, options[["models"]])
       tempMeans <- NULL

--- a/R/LSbinomialtesting.R
+++ b/R/LSbinomialtesting.R
@@ -553,7 +553,7 @@ LSbinomialtesting   <- function(jaspResults, dataset, options, state = NULL) {
     containerPlots[[paste0("priorPredictivePerformanceDistributionPlot",type)]] <- plotsPredictions
 
 
-    if (!all(ready) || (data[["nSuccesses"]] == 0 && data[["nFailures"]] == 0))
+    if (!all(ready) || (sum(data$nSuccesses, data$nFailures) == 0 && type == "Prior"))
       return()
     else {
 
@@ -763,7 +763,7 @@ LSbinomialtesting   <- function(jaspResults, dataset, options, state = NULL) {
       plotsPredictionsIndividual[[""]] <- createJaspPlot(title = "", width = 530, height = 400, aspectRatio = 0.7)
       return()
 
-    } else if ((!ready["data"] && ready["models"]) || (data[["nSuccesses"]] == 0 & data[["nFailures"]] == 0)) {
+    } else if ((!ready["data"] && ready["models"]) || (sum(data$nSuccesses, data$nFailures) == 0 && type == "Prior")) {
 
       for (i in 1:length(options[["models"]])) {
         plotsPredictionsIndividual[[options[["models"]][[i]]$name]] <- createJaspPlot(title = options[["models"]][[i]]$name,
@@ -957,7 +957,7 @@ LSbinomialtesting   <- function(jaspResults, dataset, options, state = NULL) {
         tablePredictions$addColumnInfo(name = "marginal", title = gettextf("P(Successes)"), type = "number")
     }
 
-    if (!ready["models"] || (ready["models"] && sum(data$nSuccesses, data$nFailures) == 0))
+    if (!ready["models"] || (ready["models"] && type == "Prior" && sum(data$nSuccesses, data$nFailures) == 0))
       return()
 
 

--- a/R/LSbinomialtesting.R
+++ b/R/LSbinomialtesting.R
@@ -907,12 +907,6 @@ LSbinomialtesting   <- function(jaspResults, dataset, options, state = NULL) {
 }
 .tablePredictions2LS                    <- function(jaspResults, data, ready, options, type = c("Prior", "Posterior")) {
 
-  if(!ready["data"]) {
-    data <- list(y = NULL,
-                 nSuccesses = 0,
-                 nFailures = 0)
-  }
-
   containerPlots <- .containerPrediction2PlotsLS(jaspResults, options, "binTest", type)
 
   if (is.null(containerPlots[["tablePredictions"]])) {

--- a/R/LSbinomialtesting.R
+++ b/R/LSbinomialtesting.R
@@ -937,7 +937,8 @@ LSbinomialtesting   <- function(jaspResults, dataset, options, state = NULL) {
       tablePredictions$addColumns(c(0:tempN)/tempN)
     } else {
       tablePredictions$addColumnInfo(name = "successes", title = gettext("Successes"), type = "integer")
-      tablePredictions$addColumns(0:tempN)
+      if (tempN > 0)
+        tablePredictions$addColumns(0:tempN)
     }
 
 

--- a/R/LSbinomialtesting.R
+++ b/R/LSbinomialtesting.R
@@ -907,6 +907,12 @@ LSbinomialtesting   <- function(jaspResults, dataset, options, state = NULL) {
 }
 .tablePredictions2LS                    <- function(jaspResults, data, ready, options, type = c("Prior", "Posterior")) {
 
+  if(!ready["data"]) {
+    data <- list(y = NULL,
+                 nSuccesses = 0,
+                 nFailures = 0)
+  }
+
   containerPlots <- .containerPrediction2PlotsLS(jaspResults, options, "binTest", type)
 
   if (is.null(containerPlots[["tablePredictions"]])) {


### PR DESCRIPTION
.tablePredictions2LS now assumes 0 successes and 0 failures in case no data sequence is specified, so the analysis does not crash.

fixes: https://github.com/jasp-stats/INTERNAL-jasp/issues/2657